### PR TITLE
Nalintiwary18 patch 1

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -5,6 +5,8 @@ import Link from "next/link"
 import LogoTs from './LogoTs';
 import SplineViewer from './SplineViewer';
 import { useHighlights } from '@/contexts/HighlightsContext';
+import ResultsAnnouncementStrip from "@/components/ResultsStrip";
+
 
 interface DriveImage {
     id: string;
@@ -229,6 +231,7 @@ export default function HeroSection() {
                 preloadProgress={preloadProgress}
                 isPreloadComplete={highlightsPreloaded}
             />
+            <ResultsAnnouncementStrip />
 
 
             {/* Hero Content - Shows after animation */}

--- a/components/ResultsStrip.tsx
+++ b/components/ResultsStrip.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export default function ResultsAnnouncementStrip() {
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsVisible(true);
+        }, 5000);
+
+        return () => clearTimeout(timer);
+    }, []);
+
+    if (!isVisible) return null;
+
+    return (
+        <div className="relative bg-[#330066] bg-transparent text-gray-400">
+            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent animate-pulse" />
+
+            <div className="relative flex items-center justify-center px-4 py-[0.100rem] text-xs font-thin">
+                <div className="flex items-center gap-2">
+                    <span className="animate-bounce">🎉</span>
+                    <span>Interview results will be out soon</span>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION

This pull request introduces a new client-side React component to display an announcement strip for interview results. The strip appears with a delay after the page loads and includes animated styling and messaging.

New UI feature:

* Added the `ResultsAnnouncementStrip` component in `components/ResultsStrip.tsx`, which shows a styled, animated announcement about upcoming interview results after a 5-second delay.
This pull request adds a new announcement strip to the homepage that notifies users about upcoming interview results. The main change is the creation and integration of the `ResultsAnnouncementStrip` component, which appears after a short delay.

**New feature: Interview results announcement**

* Added the `ResultsAnnouncementStrip` component in `components/ResultsStrip.tsx`, which displays a styled announcement after a 5-second delay.
* Imported the new `ResultsAnnouncementStrip` in `components/Home.tsx` and rendered it within the `HeroSection` to show the announcement on the homepage. [[1]](diffhunk://#diff-7f4fa2e23497b7d78945a75101863c238b54b1881cfd5d3439bb9f8ecd495915R8-R9) [[2]](diffhunk://#diff-7f4fa2e23497b7d78945a75101863c238b54b1881cfd5d3439bb9f8ecd495915R234)